### PR TITLE
Added exceptions in Google Drive sync process so that it fails correctly and moved the redirect url to a constant

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/data/sync/service/GoogleDriveSyncService.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/sync/service/GoogleDriveSyncService.kt
@@ -18,6 +18,7 @@ import com.google.api.client.json.jackson2.JacksonFactory
 import com.google.api.services.drive.Drive
 import com.google.api.services.drive.DriveScopes
 import com.google.api.services.drive.model.File
+import eu.kanade.tachiyomi.R
 import eu.kanade.tachiyomi.data.sync.models.SyncData
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
@@ -57,7 +58,7 @@ class GoogleDriveSyncService(context: Context, json: Json, syncPreferences: Sync
         // Check if the Google Drive service is initialized
         if (drive == null) {
             logcat(LogPriority.ERROR) { "Google Drive service not initialized" }
-            return null
+            throw Exception(context.getString(R.string.google_drive_not_signed_in))
         }
 
         val fileList = getFileList(drive)
@@ -85,7 +86,7 @@ class GoogleDriveSyncService(context: Context, json: Json, syncPreferences: Sync
         // Check if the Google Drive service is initialized
         if (drive == null) {
             logcat(LogPriority.ERROR) { "Google Drive service not initialized" }
-            return
+            throw Exception(context.getString(R.string.google_drive_not_signed_in))
         }
 
         // delete file if exists
@@ -151,6 +152,7 @@ class GoogleDriveSyncService(context: Context, json: Json, syncPreferences: Sync
 
 class GoogleDriveService(private val context: Context) {
     var googleDriveService: Drive? = null
+    private val redirectUri = "eu.kanade.google.oauth:/oauth2redirect"
     private val syncPreferences = Injekt.get<SyncPreferences>()
 
     init {
@@ -208,7 +210,7 @@ class GoogleDriveService(private val context: Context) {
         ).setAccessType("offline").build()
 
         return flow.newAuthorizationUrl()
-            .setRedirectUri("eu.kanade.google.oauth:/oauth2redirect")
+            .setRedirectUri(redirectUri)
             .setApprovalPrompt("force")
             .build()
     }
@@ -224,6 +226,10 @@ class GoogleDriveService(private val context: Context) {
             .setTransport(NetHttpTransport())
             .setClientSecrets(secrets)
             .build()
+
+        if (syncPreferences.getGoogleDriveRefreshToken() == "") {
+            throw Exception(context.getString(R.string.google_drive_not_signed_in))
+        }
 
         credential.refreshToken = syncPreferences.getGoogleDriveRefreshToken()
 
@@ -246,11 +252,13 @@ class GoogleDriveService(private val context: Context) {
                 // Token refresh failed; handle this situation
                 logcat(LogPriority.ERROR) { "Failed to refresh access token ${e.message}" }
                 logcat(LogPriority.ERROR) { "Google Drive sync will be disabled" }
+                throw e.message?.let { Exception(it) } ?: Exception("Unknown error")
             }
         } catch (e: IOException) {
             // Token refresh failed; handle this situation
             logcat(LogPriority.ERROR) { "Failed to refresh access token ${e.message}" }
             logcat(LogPriority.ERROR) { "Google Drive sync will be disabled" }
+            throw e.message?.let { Exception(it) } ?: Exception("Unknown error")
         }
     }
 
@@ -305,7 +313,7 @@ class GoogleDriveService(private val context: Context) {
             secrets.installed.clientId,
             secrets.installed.clientSecret,
             authorizationCode,
-            "eu.kanade.google.oauth:/oauth2redirect",
+            redirectUri,
         ).setGrantType("authorization_code").execute()
 
         try {

--- a/app/src/main/java/eu/kanade/tachiyomi/data/sync/service/GoogleDriveSyncService.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/sync/service/GoogleDriveSyncService.kt
@@ -152,7 +152,7 @@ class GoogleDriveSyncService(context: Context, json: Json, syncPreferences: Sync
 
 class GoogleDriveService(private val context: Context) {
     var googleDriveService: Drive? = null
-        companion object {
+    companion object {
         const val REDIRECT_URI = "eu.kanade.google.oauth:/oauth2redirect"
     }
     private val syncPreferences = Injekt.get<SyncPreferences>()

--- a/app/src/main/java/eu/kanade/tachiyomi/data/sync/service/GoogleDriveSyncService.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/sync/service/GoogleDriveSyncService.kt
@@ -152,7 +152,9 @@ class GoogleDriveSyncService(context: Context, json: Json, syncPreferences: Sync
 
 class GoogleDriveService(private val context: Context) {
     var googleDriveService: Drive? = null
-    private val redirectUri = "eu.kanade.google.oauth:/oauth2redirect"
+        companion object {
+        const val REDIRECT_URI = "eu.kanade.google.oauth:/oauth2redirect"
+    }
     private val syncPreferences = Injekt.get<SyncPreferences>()
 
     init {
@@ -210,7 +212,7 @@ class GoogleDriveService(private val context: Context) {
         ).setAccessType("offline").build()
 
         return flow.newAuthorizationUrl()
-            .setRedirectUri(redirectUri)
+            .setRedirectUri(REDIRECT_URI)
             .setApprovalPrompt("force")
             .build()
     }
@@ -313,7 +315,7 @@ class GoogleDriveService(private val context: Context) {
             secrets.installed.clientId,
             secrets.installed.clientSecret,
             authorizationCode,
-            redirectUri,
+            REDIRECT_URI,
         ).setGrantType("authorization_code").execute()
 
         try {


### PR DESCRIPTION
I added an exception to the Google Drive sync process in case the user hasn't logged in to Google Drive.

Before my changes syncing via Google Drive didn't generate any errors if the user hadn't logged in. The bug is easy to reproduce:
1. Make a clean installation of this branch
2. Select Google Drive service for syncing
3. Click "Sync Now" without signing in to the Google Drive

Then the sync happily reported that 0 errors were generated even though nothing actually was synchronized because Google Drive wasn't even signed in.

I also added exceptions in a couple of other places, since they are supposed to be treated as a failure anyway. As far as I understand, `SyncDataJob` reports that sync was successful if no exceptions were generated during it, so I think it probably makes sense to put exceptions everywhere. From a bigger point of view it would have probably made more sense to make `SyncDataJob` work the other way around: to assume failure by default, unless the syncing process reported success, but I am not sure how it can be done.

I also moved redirect url into a constant so that it is in one place.