### PR TITLE
Added automatic change of the Google Drive's "Sign In" button to something else when the user has signed in

### DIFF
--- a/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsBackupAndSyncScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsBackupAndSyncScreen.kt
@@ -464,16 +464,31 @@ object SettingsBackupAndSyncScreen : SearchableSettings {
     private fun getGoogleDrivePreferences(): List<Preference> {
         val context = LocalContext.current
         val googleDriveSync = Injekt.get<GoogleDriveService>()
-        return listOf(
-            Preference.PreferenceItem.TextPreference(
-                title = stringResource(R.string.pref_google_drive_sign_in),
-                onClick = {
-                    val intent = googleDriveSync.getSignInIntent()
-                    context.startActivity(intent)
-                },
-            ),
-            getGoogleDrivePurge(),
-        )
+        var googleDriveServiceState by remember { googleDriveSync.signedIn }
+
+        if (googleDriveServiceState) {
+            return listOf(
+                Preference.PreferenceItem.TextPreference(
+                    title = stringResource(R.string.pref_google_drive_change_account),
+                    onClick = {
+                        val intent = googleDriveSync.getSignInIntent()
+                        context.startActivity(intent)
+                    },
+                ),
+
+                getGoogleDrivePurge(),
+            )
+        } else {
+            return listOf(
+                Preference.PreferenceItem.TextPreference(
+                    title = stringResource(R.string.pref_google_drive_sign_in),
+                    onClick = {
+                        val intent = googleDriveSync.getSignInIntent()
+                        context.startActivity(intent)
+                    },
+                ),
+            )
+        }
     }
 
     @Composable

--- a/app/src/main/java/eu/kanade/tachiyomi/data/sync/service/GoogleDriveSyncService.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/sync/service/GoogleDriveSyncService.kt
@@ -5,6 +5,7 @@ import android.content.Context
 import android.content.Intent
 import android.net.Uri
 import android.util.Log
+import androidx.compose.runtime.mutableStateOf
 import com.google.api.client.auth.oauth2.TokenResponseException
 import com.google.api.client.googleapis.auth.oauth2.GoogleAuthorizationCodeFlow
 import com.google.api.client.googleapis.auth.oauth2.GoogleAuthorizationCodeTokenRequest
@@ -157,6 +158,8 @@ class GoogleDriveService(private val context: Context) {
     }
     private val syncPreferences = Injekt.get<SyncPreferences>()
 
+    var signedIn = mutableStateOf(false)
+
     init {
         initGoogleDriveService()
     }
@@ -270,6 +273,7 @@ class GoogleDriveService(private val context: Context) {
      * @param refreshToken The refresh token obtained from the SyncPreferences.
      */
     private fun setupGoogleDriveService(accessToken: String, refreshToken: String) {
+        signedIn.value = true
         val jsonFactory: JsonFactory = JacksonFactory.getDefaultInstance()
         val secrets = GoogleClientSecrets.load(
             jsonFactory,


### PR DESCRIPTION
In addition to that, also hide the "purge google drive" button until the user signs in.

Unfortunately, I am not as advanced with Kotlin and Jetpack Compose, so it took me quite a while and I couldn't figure out how to implement it without introducing a `mutableStateOf` in the `GoogleDriveService`. The problem is that the `GoogleDriveService` gets updated only after the user is redirected from the browser into the `GoogleDriveLoginActivity` which then further runs the remaining part of the authorization process in `GoogleDriveService`, so it is pretty hard to subscribe to it. So I did the easiest possible solution instead, which unfortunately introduces a useless variable in the `GoogleDriveService`.

If it doesn't look good (and I do realize that it probably doesn't), could you please kindly point me in the direction of some mechanism that would allow me to do it in a cleaner way?
Or should I do something like an Observable pattern (or something similar)? It is just that what I did feels exactly like that, but takes only 2 lines of code, so I am a bit split as to what would be the best practice.